### PR TITLE
Fix buttons.png reference in styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -370,7 +370,7 @@ ul.listing li {
 }
 
 .boxfooter .listbutton .inner {
-    background-image: url("/skins/mabola/images/buttons.png");
+    background-image: url("images/buttons.png");
 }
 
 .records-table.focus tr.selected td, .records-table tr.selected td {


### PR DESCRIPTION
Some buttons signs were not displaying correctly due to the direct reference to /skins/mabola/images/buttons.png changing it to /images/buttons.png fix the problem.
